### PR TITLE
`thumbDiameter` was exposed as a param

### DIFF
--- a/lib/flutter_fluid_slider.dart
+++ b/lib/flutter_fluid_slider.dart
@@ -121,6 +121,10 @@ class FluidSlider extends StatefulWidget {
   ///If null the value is converted to String based on [showDecimalValue]
   final String Function(double) mapValueToString;
 
+  ///The diameter of the thumb, it's also the height of the slider
+  ///
+  ///defaults to 60.0
+  final double thumbDiameter;
 
   const FluidSlider({
     Key key,
@@ -138,6 +142,7 @@ class FluidSlider extends StatefulWidget {
     this.thumbColor,
     this.mapValueToString,
     this.showDecimalValue = false,
+    this.thumbDiameter,
   })  : assert(value != null),
         assert(min != null),
         assert(max != null),
@@ -154,10 +159,12 @@ class _FluidSliderState extends State<FluidSlider>
   double _currX = 0.0;
   AnimationController _animationController;
   CurvedAnimation _thumbAnimation;
+  double thumbDiameter;
 
   @override
   initState() {
     super.initState();
+    thumbDiameter = widget.thumbDiameter ?? 60.0;
     _animationController = AnimationController(
       duration: Duration(milliseconds: 400),
       vsync: this,
@@ -211,7 +218,7 @@ class _FluidSliderState extends State<FluidSlider>
     _currX = 0.0;
     _animationController.reverse();
   }
-  
+
   void _onHorizontalDragCancel() {
     if (widget.onChangeEnd != null) {
       _handleDragEnd(_clamp(_currX));
@@ -296,7 +303,7 @@ class _FluidSliderState extends State<FluidSlider>
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         //The radius of the slider thumb control
-        final double thumbDiameter = 60.0;
+        //final double thumbDiameter = 60.0;
         //The offset of the thumb so that it does not touch the slider border when at min/max position.
         final double thumbPadding = 8.0;
         //The value by which the thum positions should interpolate.
@@ -325,8 +332,9 @@ class _FluidSliderState extends State<FluidSlider>
             thumbPositionLeft, 0.00, thumbPositionRight, 0.0);
 
         //Popped up position of slider thumb.
-        final RelativeRect endRect = RelativeRect.fromLTRB(
-            thumbPositionLeft, -65.0, thumbPositionRight, 65.0);
+        final poppedPosition = thumbDiameter + 5;
+        final RelativeRect endRect = RelativeRect.fromLTRB(thumbPositionLeft,
+            poppedPosition * -1, thumbPositionRight, poppedPosition);
 
         //Describes the position of the thumb slider.
         //Mainly useful to animate the thumb popping up.
@@ -394,10 +402,10 @@ class _FluidSliderState extends State<FluidSlider>
                         child: Center(
                           child: Text(
                             widget.mapValueToString != null
-                              ? widget.mapValueToString(widget.value)
-                              : widget.showDecimalValue
-                                  ? widget.value.toStringAsFixed(1)
-                                  : widget.value.toInt().toString(),
+                                ? widget.mapValueToString(widget.value)
+                                : widget.showDecimalValue
+                                    ? widget.value.toStringAsFixed(1)
+                                    : widget.value.toInt().toString(),
                             style: _currentValTextStyle(context),
                           ),
                         ),

--- a/lib/flutter_fluid_slider.dart
+++ b/lib/flutter_fluid_slider.dart
@@ -164,6 +164,7 @@ class _FluidSliderState extends State<FluidSlider>
   @override
   initState() {
     super.initState();
+    //The radius of the slider thumb control
     thumbDiameter = widget.thumbDiameter ?? 60.0;
     _animationController = AnimationController(
       duration: Duration(milliseconds: 400),
@@ -302,8 +303,6 @@ class _FluidSliderState extends State<FluidSlider>
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
-        //The radius of the slider thumb control
-        //final double thumbDiameter = 60.0;
         //The offset of the thumb so that it does not touch the slider border when at min/max position.
         final double thumbPadding = 8.0;
         //The value by which the thum positions should interpolate.


### PR DESCRIPTION
Because the height of the slider looks like too big on smaller devices, this PR adds the ability to set a custom diameter or height to the slider.

If no value is set, the default value is 60.0.

This change not break the current code.